### PR TITLE
Bug fix/draw polyline colours for predefined settings

### DIFF
--- a/lib/widgets/list_view_car.dart
+++ b/lib/widgets/list_view_car.dart
@@ -280,7 +280,7 @@ class _CarListViewState extends State<CarListView> {
                         );
                       }
                       polylinesState.updateColours(theme.carColourList);
-                      theme.setThemeColour(index);
+                      theme.setThemeColour(polylinesState.carActiveRouteIndex);
                       context.read<ColourSyncState>().setColoursReady(true);     
                     }
                   },
@@ -288,7 +288,7 @@ class _CarListViewState extends State<CarListView> {
                     setState(() {
                       polylinesState.setActiveRoute(index);
                     });
-                    theme.setThemeColour(index);
+                    theme.setThemeColour(polylinesState.carActiveRouteIndex);
                   },
                   child: Container(
                     decoration: BoxDecoration(

--- a/lib/widgets/list_view_motorcycle.dart
+++ b/lib/widgets/list_view_motorcycle.dart
@@ -332,7 +332,7 @@ final ValueNotifier<bool> coloursReadyNotifier = ValueNotifier(false);
                         );
                       }
                       polylinesState.updateColours(theme.motoColourList);
-                      theme.setThemeColour(index);
+                      theme.setThemeColour(polylinesState.motorcycleActiveRouteIndex);
                       context.read<ColourSyncState>().setColoursReady(true);     
                     }
                   },
@@ -342,7 +342,7 @@ final ValueNotifier<bool> coloursReadyNotifier = ValueNotifier(false);
                     setState(() {
                       polylinesState.setActiveRoute(index);
                     });
-                    theme.setThemeColour(index);
+                    theme.setThemeColour(polylinesState.motorcycleActiveRouteIndex);
                     //context.read<ColourSyncState>().setColoursReady(true); 
                   },
                   child: Container(

--- a/lib/widgets/list_view_transit.dart
+++ b/lib/widgets/list_view_transit.dart
@@ -273,7 +273,7 @@ class _TransitListViewState extends State<TransitListView> {
                         );
                       }
                       polylinesState.updateColours(theme.transitColourList);
-                      theme.setThemeColour(index);
+                      theme.setThemeColour(polylinesState.transitActiveRouteIndex);
                       context.read<ColourSyncState>().setColoursReady(true);   
                     }
                   },
@@ -283,7 +283,7 @@ class _TransitListViewState extends State<TransitListView> {
                     setState(() {
                       polylinesState.setActiveRoute(index);
                     });
-                    theme.setThemeColour(index);
+                    theme.setThemeColour(polylinesState.transitActiveRouteIndex);
                   },
                   child: Container(
                     decoration: BoxDecoration(

--- a/lib/widgets/travel_mode_buttons.dart
+++ b/lib/widgets/travel_mode_buttons.dart
@@ -101,7 +101,6 @@ void initState() {
 
   // Listen for changes in the colours
   sync.addListener(() {
-      print("sync colours ready ${sync.coloursReady}");
     if (sync.coloursReady) {
       _handlePolyline();
       sync.setColoursReady(false);
@@ -113,7 +112,6 @@ void initState() {
     _handlePolyline();
     sync.setColoursReady(false);
   }
-  print("sync colours ready ${sync.coloursReady}");
 }
 
 void _handlePolyline() {
@@ -206,8 +204,10 @@ void _handlePolyline() {
                     // Clear colours for the current polylines before redrawing them for the new mode
                     // This is to give visual feedback that that mode emisisons have not been calculated yet
                     if (selectedMode == 'motorcycling') {
-                      // But first, we need to check if the settings for motorcycling are set
-                      // If not, the polylcolours list will be empty
+                      // But first, we need to check if the settings for motorcycling are predefined
+                      // If not predefined && motocolours list is empty, we empty any existing polycolours
+                      // and draw the polylines for the current moden without any colours until the emissions are calculated
+                      // If predefined, we move to calculating the theme colours since the emisisons are already calculated
                       Settings settings = context.read<Settings>();
                       bool isPredefined = settings.useSpecifiedMotorcycle;
                       if (theme.motoColourList.isEmpty && !isPredefined) {
@@ -221,14 +221,11 @@ void _handlePolyline() {
                         polylineState.updateColours([]);
                       }
                     } else if (selectedMode == 'driving') {
-                      print(">> polylineState.colours ${polylineState.polyColours}");
-                      print(">> carcolours ${theme.carColourList}");
                       if (theme.carColourList.isEmpty) {
                         polylineState.updateColours([]);
                         polylineState.getPolyline(coordinatesState.coordinates);
                       }
                     }
-                     print(">> polylineState.colours ${polylineState.polyColours}");
                   },
                   renderBorder: false,
                   constraints: const BoxConstraints(

--- a/lib/widgets/vehicle_settings_car.dart
+++ b/lib/widgets/vehicle_settings_car.dart
@@ -59,8 +59,22 @@ class _CarSettingsState extends State<CarSettings> {
         );
 
         // Calculate emissions
-        final emissions = List<int>.generate(polylinesState.result.length, (i) => calculator.calculateEmissions(i, settings.selectedCarSize, settings.selectedCarFuelType).round());
+        // final emissions = List<int>.generate(
+        //     polylinesState.result.length,
+        //     (i) => calculator
+        //         .calculateEmissions(
+        //             i, settings.selectedCarSize, settings.selectedCarFuelType)
+        //         .round()); <-- this code produces unexpected results
 
+        // We need to calculate the emissions for the "privateVehicleResult"
+        // instead of "result". Otherwise, it will calculate the public transport emissions
+        final emissions = List<int>.generate(
+            polylinesState.resultForPrivateVehicle.length,
+            (i) => calculator
+                .calculateEmissions(
+                    i, settings.selectedCarSize, settings.selectedCarFuelType)
+                .round());
+                
         // Update state
         carState.saveEmissions(emissions);
         carState.updateVisibility(true);

--- a/lib/widgets/vehicle_settings_motorcyle.dart
+++ b/lib/widgets/vehicle_settings_motorcyle.dart
@@ -44,11 +44,18 @@ class _MotorcycleSettingsState extends State<MotorcycleSettings> {
         );
 
         // 3) Generate emissions for each route
+        // final computedEmissions = List<int>.generate( 
+        //   polylinesState.result.length,
+        //   (i) => calculator.calculateEmission(i).round(),  <-- this code produces unexpected results
+        // );
+
+        // We need to calculate the emissions for the "privateVehicleResult"
+        // instead of "result". Otherwise, it will calculate the public transport emissions
         final computedEmissions = List<int>.generate(
-          polylinesState.result.length,
+          polylinesState.resultForPrivateVehicle.length,
           (i) => calculator.calculateEmission(i).round(),
         );
-
+        
         // 4) Populate PrivateMotorcycleState and show the list
         motorcycleState.saveEmissions(computedEmissions);
         motorcycleState.updateVisibility(true);


### PR DESCRIPTION
Fixed:

- The length of the polyline list was not updated when switching from “Transit” to “Driving” or “Motorcycling” modes (only when predefined settings were  being used)
-- Outcome: The polyline colours were not updating correctly when switching modes
-- Reason: Using the wrong result length to create the route list
-- Solution: Change the code to point to the actual PrivateVehicleResults

- The polylines were not changing colour at all for “Motorcycling” mode
-- Outcome: the polylines remind gray
-- Reason: when switching mode the polyline colours are reset to calculate the new ones for the new mode
-- Solution: Add a catch for predefined motorcycle settings where we don’t empty the list of polycolours first and redraw the polylines, instead we move onto calculating the theme colours since the emissions are already calculated
